### PR TITLE
Make pull requests work with travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,11 @@ before_script:
 - pip install mkdocs
 - pip install MarkdownHighlight
 script:
-- openssl aes-256-cbc -K $encrypted_1d262b48bc9b_key -iv $encrypted_1d262b48bc9b_iv -in deploy-key.enc -out deploy_key -d
-- chmod 600 deploy_key
-- eval `ssh-agent -s`
-- if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then ssh-add deploy_key; fi
+- if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then openssl aes-256-cbc -K $encrypted_1d262b48bc9b_key -iv $encrypted_1d262b48bc9b_iv -in deploy-key.enc -out deploy_key -d; chmod 600 deploy_key; eval `ssh-agent -s`; ssh-add deploy_key; fi
 - git config user.name "Automatic Publish"
 - git config user.email "djw8605@gmail.com"
 - git remote add gh-token "${GH_REF}";
+- if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then mkdocs -v build; fi
 - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then git fetch gh-token && git fetch gh-token gh-pages:gh-pages; fi
 - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then echo "Pushing to github"; PYTHONPATH=src/ mkdocs gh-deploy -v --clean --remote-name gh-token; git push gh-token gh-pages; fi;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
 - git config user.name "Automatic Publish"
 - git config user.email "djw8605@gmail.com"
 - git remote add gh-token "${GH_REF}";
-- if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then mkdocs -v build; fi
+- if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then PYTHONPATH=src/ mkdocs -v build; fi
 - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then git fetch gh-token && git fetch gh-token gh-pages:gh-pages; fi
 - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then echo "Pushing to github"; PYTHONPATH=src/ mkdocs gh-deploy -v --clean --remote-name gh-token; git push gh-token gh-pages; fi;
 


### PR DESCRIPTION
The secure token is not available in pull requests, so any command
that tries to access it will fail the travis-ci build.  Therefore, we must
put most of the travis-ci script in if statements.