### PR TITLE
Fix mkdocs.yml section layout

### DIFF
--- a/docs/OSGSecurityAnnouncements.md
+++ b/docs/OSGSecurityAnnouncements.md
@@ -5,7 +5,7 @@ All security announcements related with vulnerabilities are listed here.
 | Date        | Title                                                 | Contents/Link       |   Risk        |
 |-------------|-------------------------------------------------------|---------------------|---------------|
 | 2018-08-17  | CPU speculative execution vulnerabilities (Foreshadow)| [OSG-SEC-2018-08-17](/vulns/OSG-SEC-2018-08-17-Foreshadow.md)|     |
-| 2018-05-08  | CPU speculative execution vulnerabilities (Spectre and Meltdown)| [OSG-SEC-2018-01-04 UPDATE](https://github.com/opensciencegrid/security/blob/master/docs/vulns/OSG-SEC-2018-05-08-Meltdown-Spectre-Update.md)|     |
-| 2018-01-22  | CPU speculative execution vulnerabilities (Spectre and Meltdown)| [OSG-SEC-2018-01-04 UPDATE](https://github.com/opensciencegrid/security/blob/master/docs/vulns/OSG-SEC-2018-01-22-Meltdown-Spectre-Update.md)|     |
-| 2018-01-10  | CPU speculative execution vulnerabilities (Spectre and Meltdown)| [OSG-SEC-2018-01-04 UPDATE](https://github.com/opensciencegrid/security/blob/master/docs/vulns/OSG-SEC-2018-01-10-Meltdown-Spectre-Update.md)|     |
-| 2018-01-04  | CPU speculative execution vulnerabilities (Spectre and Meltdown)| [OSG-SEC-2018-01-04](https://github.com/opensciencegrid/security/blob/master/docs/vulns/OSG-SEC-2018-01-04-Meltdown-Spectre.md)|     |
+| 2018-05-08  | CPU speculative execution vulnerabilities (Spectre and Meltdown)| [OSG-SEC-2018-01-04 UPDATE](/vulns/OSG-SEC-2018-05-08-Meltdown-Spectre-Update.md)|     |
+| 2018-01-22  | CPU speculative execution vulnerabilities (Spectre and Meltdown)| [OSG-SEC-2018-01-04 UPDATE](/vulns/OSG-SEC-2018-01-22-Meltdown-Spectre-Update.md)|     |
+| 2018-01-10  | CPU speculative execution vulnerabilities (Spectre and Meltdown)| [OSG-SEC-2018-01-04 UPDATE](/vulns/OSG-SEC-2018-01-10-Meltdown-Spectre-Update.md)|     |
+| 2018-01-04  | CPU speculative execution vulnerabilities (Spectre and Meltdown)| [OSG-SEC-2018-01-04](/vulns/OSG-SEC-2018-01-04-Meltdown-Spectre.md)|     |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,8 +8,14 @@ theme:
 pages:
 - Home: 'index.md'
 - Security Team: 'SecurityTeamMembers.md'
-- Security Announcements: 'OSGSecurityAnnouncements.md'
-  - 'OSG-SEC-2018-08-17 Foreshadow': 'vulns/OSG-SEC-2018-08-17-Foreshadow.md'
+- Security Announcements:
+  - Overview: 'OSGSecurityAnnouncements.md'
+  - Announcement Details:
+    - OSG-SEC-2018-08-17 Foreshadow: 'vulns/OSG-SEC-2018-08-17-Foreshadow.md'
+    - OSG-SEC-2018-05-08 Meltdown-Spectre Update: 'vulns/OSG-SEC-2018-05-08-Meltdown-Spectre-Update.md'
+    - OSG-SEC-2018-01-22 Meltdown-Spectre Update: 'vulns/OSG-SEC-2018-01-22-Meltdown-Spectre-Update.md'
+    - OSG-SEC-2018-01-10 Meltdown-Spectre Update: 'vulns/OSG-SEC-2018-01-10-Meltdown-Spectre-Update.md'
+    - OSG-SEC-2018-01-04 Meltdown-Spectre Update: 'vulns/OSG-SEC-2018-01-04-Meltdown-Spectre.md'
 - CILogon OSG CA:
   - CILogon OSG CA: 'OSGCertificateService.md'
   - Frequently Asked Questions (FAQ): 'CILogonOSGFAQ.md'


### PR DESCRIPTION
@jteheran the issue was that a section in `mkdocs.yml` can't be associated with a specific page but you can have multiple pages underneath them.